### PR TITLE
Hide action button VS Code and show all branches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,4 +85,6 @@
       ]
     },
   },
+  "scm.graph.badges": "all",
+  "scm.showActionButton": false,
 }


### PR DESCRIPTION
Changes the VS Code Workspace settings.

Y'all should probably copy `  "scm.showActionButton": false,` into y'all's global VS Code settings.