### PR TITLE
Clean up RotateToHub telemetry using Suppliers

### DIFF
--- a/src/main/java/frc/robot/DashboardManager.java
+++ b/src/main/java/frc/robot/DashboardManager.java
@@ -1,7 +1,8 @@
 package frc.robot;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
-
+import java.util.function.Supplier;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
@@ -133,15 +134,18 @@ public interface DashboardManager {
     // =====================================
     // Commands: RotateToHub
     // =====================================
-    static void updateRotateToHubInit(boolean useShootingCalculator) {
-        SmartDashboard.putBoolean("Enable Shooting Calculator", useShootingCalculator);
-    }
-
-    static void updateRotateToHub(Pose2d currentPose, double targetHeading) {
-        SmartDashboard.putNumber("Robot Rotation", round(currentPose.getRotation().getDegrees(), 2));
-        SmartDashboard.putNumber("Target Heading", round(Math.toDegrees(targetHeading), 2));
-        SmartDashboard.putNumber("Angle Difference",
-            round(Math.toDegrees(targetHeading - currentPose.getRotation().getRadians()), 2));
+    static void setupRotateToHub(BooleanSupplier useShootingCalculatorSupplier, Supplier<Pose2d> currentPoseSupplier,
+        DoubleSupplier targetHeadingSupplier, DoubleSupplier angDiffSupplier) {
+        SmartDashboard.putData("RotateToHub Telemetry", builder -> { // @formatter:off
+            builder.addBooleanProperty("Enable Shooting Calculator",
+                useShootingCalculatorSupplier, null);
+            builder.addDoubleProperty("Robot Rotation",
+                () -> round(currentPoseSupplier.get().getRotation().getDegrees(), 1), null);
+            builder.addDoubleProperty("Target Heading",
+                () -> round(Math.toDegrees(targetHeadingSupplier.getAsDouble()), 1), null);
+            builder.addDoubleProperty("Angle Difference",
+                () -> round(Math.toDegrees(angDiffSupplier.getAsDouble()), 1), null);
+        }); // @formatter:on
     }
 
 

--- a/src/main/java/frc/robot/commands/RotateToHub.java
+++ b/src/main/java/frc/robot/commands/RotateToHub.java
@@ -23,11 +23,14 @@ public class RotateToHub extends Command {
 
     private final Drivetrain drivetrain;
     private final SwerveRequest.FieldCentric swerveRequest = new SwerveRequest.FieldCentric();
+    private Pose2d currentPose;
     private boolean useShootingCalculator;
+    private double targetHeading;
 
     public RotateToHub(Drivetrain drivetrain) {
         this.drivetrain = drivetrain;
         PID_CONTROLLER.enableContinuousInput(-Math.PI, Math.PI);
+        registerTelemetry();
     }
 
     public RotateToHub(Drivetrain drivetrain, boolean useShootingCalculator) {
@@ -35,21 +38,27 @@ public class RotateToHub extends Command {
         this.useShootingCalculator = useShootingCalculator;
     }
 
+    private void registerTelemetry() { // @formatter:off
+        DashboardManager.setupRotateToHub(
+            () -> this.useShootingCalculator,
+            () -> this.currentPose != null ? this.currentPose : new Pose2d(),
+            () -> this.targetHeading,
+            () -> this.currentPose != null ? this.targetHeading - this.currentPose.getRotation().getRadians() : 0.0
+        ); // @formatter:on
+    }
+
     @Override
     public void initialize() {
         Controller.allowControllerRotation = false;
         PID_CONTROLLER.reset();
-        DashboardManager.updateRotateToHubInit(useShootingCalculator);
     }
 
     @Override
     public void execute() {
-        Pose2d currentPose = drivetrain.getState().Pose;
-        double targetHeading = useShootingCalculator
+        currentPose = drivetrain.getState().Pose;
+        targetHeading = useShootingCalculator
             ? ShootingCalculator.calculate(drivetrain, DashboardManager.getFlywheelSpeedMultiplier()).robotHeading()
             : getRobotToHubAngle(drivetrain);
-
-        DashboardManager.updateRotateToHub(currentPose, targetHeading);
 
         // --- 1. Calculate Feedforward (Predictive) ---
         // Get field-centric speeds


### PR DESCRIPTION
Used Suppliers to clean up RotateToHub telemetry (removed `updateRotateToHub`) and make read-only fields actually read-only.

@NicholasFlamy Can you give this a thorough review? I'm not sure of myself but I don't know why.