### PR TITLE
Remove Sebastian from `CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-** @NicholasFlamy @EthanYLeong @adizaveri @tomgagnier @Sebtronixx
+** @NicholasFlamy @EthanYLeong @adizaveri @tomgagnier


### PR DESCRIPTION
Sebastian isn't really a part of programming this season, and Mr. Geist says that he doesn't even read his emails. Also, Mr. Geist keeps getting forwarded Sebastian's review requests, and it's cluttering his inbox.

If Sebastian returns to programming then we can add him back.