### PR TITLE
Add getHomeTarget method for homeRunFlywheel command

### DIFF
--- a/src/main/java/frc/robot/Utilities.java
+++ b/src/main/java/frc/robot/Utilities.java
@@ -72,4 +72,30 @@ public interface Utilities {
         motor.getConfigurator().apply(config);
         return motor;
     }
+
+    /**
+     * @return Returns a translation2d of the spot where the robot should shoot when shooting from neutral zone into
+     *         home.
+     */
+    static Translation2d getHomeTarget(Drivetrain drivetrain) {
+        // In aim handler, we have a dead zone between y = 4.25 and y = 3.75, so the robot doesn't rotate in that space.
+        // But this method is to be used for shootingCalculator and finding the speed to set the flywheel, so I
+        // don't believe we should have a deadzone for not being able to shoot fuel, as it could be catastrophic
+        // if our pose is incorrect.
+        if (drivetrain.getState().Pose.getY() > 4.00) {
+            return getUpperHome();
+        } else {
+            return getLowerHome();
+        }
+    }
+
+    /** @return Translation2d of the Upper Home for the current Alliance. */
+    static Translation2d getUpperHome() {
+        return Robot.isBlueAlliance ? Constants.UPPER_HOMES.get(0) : Constants.UPPER_HOMES.get(1);
+    }
+
+    /** @return Translation2d of the Lower Home for the current Alliance. */
+    static Translation2d getLowerHome() {
+        return Robot.isBlueAlliance ? Constants.LOWER_HOMES.get(0) : Constants.LOWER_HOMES.get(1);
+    }
 }

--- a/src/main/java/frc/robot/commands/RobotCommands.java
+++ b/src/main/java/frc/robot/commands/RobotCommands.java
@@ -26,21 +26,11 @@ public class RobotCommands {
         aimAtHub =
             new AimAtTarget(drivetrain, swerveRequest, flywheel, Utilities::getHubPosition, HUB_FLYWHEEL_SPEEDS_MAP);
         aimAtUpperHome =
-            new AimAtTarget(drivetrain, swerveRequest, flywheel, RobotCommands::getUpperHome, HOME_FLYWHEEL_SPEEDS_MAP);
+            new AimAtTarget(drivetrain, swerveRequest, flywheel, Utilities::getUpperHome, HOME_FLYWHEEL_SPEEDS_MAP);
         aimAtLowerHome =
-            new AimAtTarget(drivetrain, swerveRequest, flywheel, RobotCommands::getLowerHome, HOME_FLYWHEEL_SPEEDS_MAP);
+            new AimAtTarget(drivetrain, swerveRequest, flywheel, Utilities::getLowerHome, HOME_FLYWHEEL_SPEEDS_MAP);
         aimHandler = new AimHandler(drivetrain, aimAtHub, aimAtUpperHome, aimAtLowerHome);
         // paths = new Paths(drivetrain);
         shootFuel = new ShootFuel(flywheel, hopper, drivetrain);
-    }
-
-    /** @return Translation2d of the Upper Home for the current Alliance. */
-    static Translation2d getUpperHome() {
-        return Robot.isBlueAlliance ? Constants.UPPER_HOMES.get(0) : Constants.UPPER_HOMES.get(1);
-    }
-
-    /** @return Translation2d of the Lower Home for the current Alliance. */
-    static Translation2d getLowerHome() {
-        return Robot.isBlueAlliance ? Constants.LOWER_HOMES.get(0) : Constants.LOWER_HOMES.get(1);
     }
 }

--- a/src/main/java/frc/robot/controller/Controller.java
+++ b/src/main/java/frc/robot/controller/Controller.java
@@ -83,7 +83,7 @@ public abstract class Controller {
         lowerIntake().whileTrue(intake.testExtender());
         // raiseIntake().whileTrue(intake.raiseArmFinalImplementation());
         aimHandler().whileTrue(commands.aimHandler);
-        manualFlywheel().whileTrue(flywheel.tunableFlywheelVoltageCommand());
+        manualFlywheel().whileTrue(flywheel.tunableFlywheelSpeedCommand());
         seedFieldCentric().onTrue(drivetrain.runOnce(drivetrain::seedFieldCentric));
         reverse().whileTrue(intake.reverseScooper());
 

--- a/src/main/java/frc/robot/subsystems/Flywheel.java
+++ b/src/main/java/frc/robot/subsystems/Flywheel.java
@@ -113,9 +113,8 @@ public class Flywheel extends SubsystemBase {
 
     /** Starts flywheel at constant speed for when the robot is shooting, but NOT into the hub. */
     public void homeRunFlywheel() {
-        // THIS NEEDS TO BE EDITED TO USE THE INTERPOLATION TABLE FOR SHOOTING FROM NEUTRAL ZONE
         var shotSolution =
-            ShootingCalculator.calculate(drivetrain, getHubPosition(), Constants.HOME_FLYWHEEL_SPEEDS_MAP); // temp get hub
+            ShootingCalculator.calculate(drivetrain, getHomeTarget(drivetrain), Constants.HOME_FLYWHEEL_SPEEDS_MAP);
         targetFlywheelSpeed = shotSolution.flywheelSpeed();
         double calculatedVoltage = feedforward.calculateWithVelocities(currentFlywheelSpeed, targetFlywheelSpeed);
         setFlywheelMotorVoltages(calculatedVoltage);


### PR DESCRIPTION
I moved the getUpperHome and getLowerHome methods into utilities so I would be able to use those methods for my new getHomeTarget method, which just returns the translation2d of where the robot is shooting so we can pass the target into the shootingcalculator method. I decided to not have a dead zone, as I believe removing the ability to shoot fuel based on being in a certain area could be problematic and lead to other issues. It's also just my fault if I shoot in the middle of the field while not aiming at an appropriate target.

Also changed the controller to use the tunableFlywheelSpeed command, as that's the command we will use when making our interpolation table, as the table is velocity vs. distance, not voltage vs. distance.