### PR TITLE
Implement DriverStation errors if devices and ports are not correct

### DIFF
--- a/macropad/boot.py
+++ b/macropad/boot.py
@@ -1,4 +1,11 @@
 import usb_hid
+import supervisor
+
+# Set custom USB identification strings for the Driver Station app.
+supervisor.set_usb_identification(
+    manufacturer="Team 6705",
+    product="CircuitPython Macropad"
+)
 
 GAMEPAD_REPORT_DESCRIPTOR = bytes((
     0x05, 0x01,  # Usage Page (Generic Desktop Ctrls)

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -1,6 +1,7 @@
 package frc.robot;
 
 import static frc.robot.utilities.FieldUtils.*;
+import frc.robot.utilities.HardwareUtils;
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
@@ -84,6 +85,11 @@ public class Robot extends TimedRobot {
         DashboardManager.setupRobotInit(combinedFieldWidget, leftCamFieldWidget, rightCamFieldWidget, autoChooser,
             drivetrain, photonVision);
         CommandScheduler.getInstance().schedule(PathfindingCommand.warmupCommand());
+
+        // Run controller port check every 1.0 seconds while disabled
+        addPeriodic(() -> {
+            if (DriverStation.isDisabled()) HardwareUtils.checkDriverStationPorts();
+        }, 1.0);
     }
 
     @Override

--- a/src/main/java/frc/robot/utilities/HardwareUtils.java
+++ b/src/main/java/frc/robot/utilities/HardwareUtils.java
@@ -5,11 +5,44 @@ import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
+import edu.wpi.first.wpilibj.DriverStation;
 
 /**
  * import static frc.robot.utilities.HardwareUtils.*;
  */
 public interface HardwareUtils {
+    /**
+     * Checks the Driver Station to ensure the correct controllers are plugged into the expected ports. Expects an Xbox
+     * Controller on Port 0 and a CircuitPython Macropad (GenericHID) on Port 4.
+     */
+    static boolean checkDriverStationPorts() {
+        boolean allOkay = true;
+
+        if (!DriverStation.isJoystickConnected(0)) {
+            DriverStation.reportWarning("Port 0: No controller connected! Expected an Xbox Controller.", false);
+            allOkay = false;
+        } else if (!DriverStation.getJoystickIsXbox(0)) {
+            DriverStation.reportWarning("Port 0: Connected device is NOT an Xbox Controller!", false);
+            allOkay = false;
+        }
+
+        if (!DriverStation.isJoystickConnected(4)) {
+            DriverStation.reportWarning("Port 4: No device connected! Expected a CircuitPython Macropad.", false);
+            allOkay = false;
+        } else {
+            String joystickName = DriverStation.getJoystickName(4);
+            // Default CircuitPython HID devices usually contain these strings unless renamed in boot.py
+            if (joystickName != null && !joystickName.toLowerCase().contains("macropad")
+                && !joystickName.toLowerCase().contains("circuitpython")) {
+                DriverStation.reportWarning("Port 4: Connected device is '" + joystickName + "'. Expected a Macropad.",
+                    false);
+                allOkay = false;
+            }
+        }
+
+        return allOkay;
+    }
+
     /**
      * Applies a gear ratio to a TalonFX motor so that getPosition(), getVelocity(), etc., automatically return
      * mechanism rotations instead of motor revolutions.

--- a/src/main/java/frc/robot/utilities/HardwareUtils.java
+++ b/src/main/java/frc/robot/utilities/HardwareUtils.java
@@ -31,7 +31,7 @@ public interface HardwareUtils {
             allOkay = false;
         } else {
             String joystickName = DriverStation.getJoystickName(4);
-            // Default CircuitPython HID devices usually contain these strings unless renamed in boot.py
+            // We check for the device name defined in boot.py
             if (joystickName != null && !joystickName.toLowerCase().contains("macropad")
                 && !joystickName.toLowerCase().contains("circuitpython")) {
                 DriverStation.reportWarning("Port 4: Connected device is '" + joystickName + "'. Expected a Macropad.",


### PR DESCRIPTION
Closes #131.

Note that Windows aggressively caches USB device names based on their hardware ID. So even after we restart the Macropad, Windows might still display the old name because it refuses to re-read the USB descriptors.

To force Windows (and the Driver Station) to see its new custom name:
1. Plug Macropad in and open Device Manager.
2. Expand the Human Interface Devices or Sound, video and game controllers section.
3. Find Macropad (probably under its old name, or as a generic "USB Input Device").
4. Right-click it and select Uninstall device. (If there are multiple entries for the Macropad, uninstall them all).
5. Unplug the Macropad from the USB port and plug it back in.

Windows should now read the boot.py strings, and the new name should appear in the Driver Station list.