### PR TITLE
Fix incorrect filename in `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ task checkMacropadCode {
         // In such a case, functionality will not be impacted.
         def DDriveFile = file('D:/code.py')
         def DDriveFileExists = DDriveFile.exists()
-        def macropadFile = DDriveFileExists ? tempFile : file('E:/code.py')
+        def macropadFile = DDriveFileExists ? DDriveFile : file('E:/code.py')
 
         // Prints to terminal
         if (!localFile.exists()) {


### PR DESCRIPTION
I have no idea how this went uncaught for so long... this bug is present in `main` and `comp` but somehow deploying code at comp worked even when the Macropad was plugged in (I think), so I just have no clue how this was working. But hey ho. Here's the fix.