### PR TITLE
Automate competition mode via FMS detection

### DIFF
--- a/elastic-layout.json
+++ b/elastic-layout.json
@@ -32,55 +32,6 @@
             }
           },
           {
-            "title": "Match Time Remaining",
-            "x": 0.0,
-            "y": 576.0,
-            "width": 384.0,
-            "height": 192.0,
-            "type": "Match Time",
-            "properties": {
-              "topic": "/SmartDashboard/Hub Shift and Times/Match Time Remaining",
-              "period": 0.06,
-              "data_type": "double",
-              "time_display_mode": "Minutes and Seconds",
-              "red_start_time": 20,
-              "yellow_start_time": 30
-            }
-          },
-          {
-            "title": "Is Hub Active",
-            "x": 384.0,
-            "y": 576.0,
-            "width": 448.0,
-            "height": 192.0,
-            "type": "Boolean Box",
-            "properties": {
-              "topic": "/SmartDashboard/Hub Shift and Times/Is Hub Active",
-              "period": 0.06,
-              "data_type": "boolean",
-              "true_color": 4283215696,
-              "false_color": 4294198070,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "Hub Shift Time Remaining",
-            "x": 832.0,
-            "y": 576.0,
-            "width": 384.0,
-            "height": 192.0,
-            "type": "Match Time",
-            "properties": {
-              "topic": "/SmartDashboard/Hub Shift and Times/Hub Shift Time Remaining",
-              "period": 0.06,
-              "data_type": "double",
-              "time_display_mode": "Minutes and Seconds",
-              "red_start_time": 20,
-              "yellow_start_time": 30
-            }
-          },
-          {
             "title": "photonvision_Port_1184_Output_MJPEG_Server",
             "x": 1472.0,
             "y": 128.0,
@@ -174,6 +125,55 @@
                 360.0
               ]
             }
+          },
+          {
+            "title": "Match Time Remaining",
+            "x": 0.0,
+            "y": 576.0,
+            "width": 384.0,
+            "height": 192.0,
+            "type": "Match Time",
+            "properties": {
+              "topic": "/SmartDashboard/Match Times/Match Time Remaining",
+              "period": 0.06,
+              "data_type": "double",
+              "time_display_mode": "Minutes and Seconds",
+              "red_start_time": 20,
+              "yellow_start_time": 30
+            }
+          },
+          {
+            "title": "Hub Shift Time Remaining",
+            "x": 832.0,
+            "y": 576.0,
+            "width": 384.0,
+            "height": 192.0,
+            "type": "Match Time",
+            "properties": {
+              "topic": "/SmartDashboard/Match Times/Hub Shift Time Remaining",
+              "period": 0.06,
+              "data_type": "double",
+              "time_display_mode": "Minutes and Seconds",
+              "red_start_time": 20,
+              "yellow_start_time": 30
+            }
+          },
+          {
+            "title": "Is Hub Active",
+            "x": 384.0,
+            "y": 576.0,
+            "width": 448.0,
+            "height": 192.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/SmartDashboard/Match Times/Is Hub Active",
+              "period": 0.06,
+              "data_type": "boolean",
+              "true_color": 4283215696,
+              "false_color": 4294198070,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
           }
         ]
       }
@@ -219,55 +219,6 @@
               "topic": "/SmartDashboard/Flywheel Speed Multiplier",
               "period": 0.06,
               "data_type": "double"
-            }
-          },
-          {
-            "title": "Match Time Remaining",
-            "x": 0.0,
-            "y": 704.0,
-            "width": 448.0,
-            "height": 192.0,
-            "type": "Match Time",
-            "properties": {
-              "topic": "/SmartDashboard/Hub Shift and Times/Match Time Remaining",
-              "period": 0.06,
-              "data_type": "double",
-              "time_display_mode": "Minutes and Seconds",
-              "red_start_time": 20,
-              "yellow_start_time": 30
-            }
-          },
-          {
-            "title": "Is Hub Active",
-            "x": 448.0,
-            "y": 704.0,
-            "width": 384.0,
-            "height": 192.0,
-            "type": "Boolean Box",
-            "properties": {
-              "topic": "/SmartDashboard/Hub Shift and Times/Is Hub Active",
-              "period": 0.06,
-              "data_type": "boolean",
-              "true_color": 4283215696,
-              "false_color": 4294198070,
-              "true_icon": "None",
-              "false_icon": "None"
-            }
-          },
-          {
-            "title": "Hub Shift Time Remaining",
-            "x": 832.0,
-            "y": 704.0,
-            "width": 448.0,
-            "height": 192.0,
-            "type": "Match Time",
-            "properties": {
-              "topic": "/SmartDashboard/Hub Shift and Times/Hub Shift Time Remaining",
-              "period": 0.06,
-              "data_type": "double",
-              "time_display_mode": "Minutes and Seconds",
-              "red_start_time": 20,
-              "yellow_start_time": 30
             }
           },
           {
@@ -519,6 +470,55 @@
                 640.0,
                 360.0
               ]
+            }
+          },
+          {
+            "title": "Match Time Remaining",
+            "x": 0.0,
+            "y": 704.0,
+            "width": 448.0,
+            "height": 192.0,
+            "type": "Match Time",
+            "properties": {
+              "topic": "/SmartDashboard/Match Times/Match Time Remaining",
+              "period": 0.06,
+              "data_type": "double",
+              "time_display_mode": "Minutes and Seconds",
+              "red_start_time": 20,
+              "yellow_start_time": 30
+            }
+          },
+          {
+            "title": "Hub Shift Time Remaining",
+            "x": 832.0,
+            "y": 704.0,
+            "width": 448.0,
+            "height": 192.0,
+            "type": "Match Time",
+            "properties": {
+              "topic": "/SmartDashboard/Match Times/Hub Shift Time Remaining",
+              "period": 0.06,
+              "data_type": "double",
+              "time_display_mode": "Minutes and Seconds",
+              "red_start_time": 20,
+              "yellow_start_time": 30
+            }
+          },
+          {
+            "title": "Is Hub Active",
+            "x": 448.0,
+            "y": 704.0,
+            "width": 384.0,
+            "height": 192.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/SmartDashboard/Match Times/Is Hub Active",
+              "period": 0.06,
+              "data_type": "boolean",
+              "true_color": 4283215696,
+              "false_color": 4294198070,
+              "true_icon": "None",
+              "false_icon": "None"
             }
           }
         ]

--- a/src/main/java/frc/robot/DashboardManager.java
+++ b/src/main/java/frc/robot/DashboardManager.java
@@ -46,7 +46,7 @@ public interface DashboardManager {
             builder.addDoubleProperty("Distance to Hub (m)",
                 () -> round(getTargetDistance(drivetrain, getHubPosition()), 2), null);
         });
-        if (!Robot.IS_COMPETITION) SmartDashboard.putData("Aim At Target PID Controller", AimAtTarget.PID_CONTROLLER);
+        SmartDashboard.putData("Debug/Aim At Target PID Controller", AimAtTarget.PID_CONTROLLER);
         SmartDashboard.putData("Camera Poses", builder -> {
             builder.addDoubleProperty("Left Camera X", () -> round(photonVision.leftCamPose.getX(), 2), null);
             builder.addDoubleProperty("Left Camera Y", () -> round(photonVision.leftCamPose.getY(), 2), null);
@@ -196,8 +196,8 @@ public interface DashboardManager {
     // =====================================
     // Controllers
     // =====================================
-    static void setupController(SendableChooser<Controller> controllerChooser) {
-        if (!Robot.IS_COMPETITION) SmartDashboard.putData("Controller Chooser", controllerChooser);
+    static void setupControllerChooser(SendableChooser<Controller> controllerChooser) {
+        SmartDashboard.putData("Debug/Controller Chooser", controllerChooser);
     }
 
     // =====================================

--- a/src/main/java/frc/robot/DashboardManager.java
+++ b/src/main/java/frc/robot/DashboardManager.java
@@ -60,13 +60,13 @@ public interface DashboardManager {
         });
     }
 
-
     static void updateRobotPeriodic(Drivetrain drivetrain, Translation2d target) {
-        // Remaining time in the current period (Auto/Teleop)
-        SmartDashboard.putNumber("Hub Shift and Times/Match Time Remaining", round(DriverStation.getMatchTime(), 1));
-        SmartDashboard.putNumber("Hub Shift and Times/Hub Shift Time Remaining", round(getHubShiftTimeRemaining(), 1));
-        SmartDashboard.putBoolean("Hub Shift and Times/Is Hub Active", isHubActive());
-        SmartDashboard.putString("Hub Shift and Times/Game Specific Message", DriverStation.getGameSpecificMessage());
+        if (DriverStation.isFMSAttached()) {
+            SmartDashboard.putNumber("Match Times/Match Time Remaining", round(DriverStation.getMatchTime(), 1));
+            SmartDashboard.putNumber("Match Times/Hub Shift Time Remaining", round(getHubShiftTimeRemaining(), 1));
+            SmartDashboard.putBoolean("Match Times/Is Hub Active", isHubActive());
+            SmartDashboard.putString("Match Times/Game Specific Message", DriverStation.getGameSpecificMessage());
+        }
         SmartDashboard.putBoolean("In Home", inHome(drivetrain));
     }
 

--- a/src/main/java/frc/robot/DashboardManager.java
+++ b/src/main/java/frc/robot/DashboardManager.java
@@ -46,7 +46,7 @@ public interface DashboardManager {
             builder.addDoubleProperty("Distance to Hub (m)",
                 () -> round(getTargetDistance(drivetrain, getHubPosition()), 2), null);
         });
-        SmartDashboard.putData("Debug/Aim At Target PID Controller", AimAtTarget.PID_CONTROLLER);
+        putDebugData("Aim At Target PID Controller", AimAtTarget.PID_CONTROLLER);
         SmartDashboard.putData("Camera Poses", builder -> {
             builder.addDoubleProperty("Left Camera X", () -> round(photonVision.leftCamPose.getX(), 2), null);
             builder.addDoubleProperty("Left Camera Y", () -> round(photonVision.leftCamPose.getY(), 2), null);
@@ -197,7 +197,7 @@ public interface DashboardManager {
     // Controllers
     // =====================================
     static void setupControllerChooser(SendableChooser<Controller> controllerChooser) {
-        SmartDashboard.putData("Debug/Controller Chooser", controllerChooser);
+        putDebugData("Controller Chooser", controllerChooser);
     }
 
     // =====================================

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -33,13 +33,12 @@ import frc.robot.subsystems.*;
  * the Main.java file in the project.
  */
 public class Robot extends TimedRobot {
-    public static final boolean IS_COMPETITION = false;
     /** The only instance of Drivetrain. */
     private final Drivetrain drivetrain = TunerConstants.createDrivetrain();
     /** Use this to create requests for driving the robot and use {@link #drivetrain} to apply them. */
     private final SwerveRequest.FieldCentric controllerSwerveReq =
         new SwerveRequest.FieldCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage); // Use open-loop control for drive motors
-    private final Controller controller = IS_COMPETITION ? new Xbox(0) : new MultiController();
+    private final Controller controller = new MultiController();
     private final OperatorConsole operatorConsole = new OperatorConsole();
     @SuppressWarnings("unused")
     private final PhotonVision photonVision = new PhotonVision(drivetrain::addVisionMeasurement);
@@ -98,10 +97,8 @@ public class Robot extends TimedRobot {
     @Override
     public void autonomousInit() {
         DriverStation.getAlliance().ifPresent(fms_alliance -> isBlueAlliance = fms_alliance == Alliance.Blue);
-        if (IS_COMPETITION) elasticTabPublisher.set("Autonomous");
-        if (autoChooser.getSelected() != null) {
-            CommandScheduler.getInstance().schedule(autoChooser.getSelected());
-        }
+        if (DriverStation.isFMSAttached()) elasticTabPublisher.set("Autonomous");
+        if (autoChooser.getSelected() != null) CommandScheduler.getInstance().schedule(autoChooser.getSelected());
     }
 
     @Override
@@ -110,7 +107,7 @@ public class Robot extends TimedRobot {
     @Override
     public void teleopInit() {
         DriverStation.getAlliance().ifPresent(fms_alliance -> isBlueAlliance = fms_alliance == Alliance.Blue);
-        if (IS_COMPETITION) elasticTabPublisher.set("Teleoperated");
+        if (DriverStation.isFMSAttached()) elasticTabPublisher.set("Teleoperated");
         if (autoChooser.getSelected() != null) {
             CommandScheduler.getInstance().cancel(autoChooser.getSelected());
         }

--- a/src/main/java/frc/robot/controller/MultiController.java
+++ b/src/main/java/frc/robot/controller/MultiController.java
@@ -3,8 +3,8 @@ package frc.robot.controller;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.DashboardManager;
 
 /**
  * Controller that will use the {@link Controller} selected by the dashboard widget. For example, you can select the
@@ -12,110 +12,119 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
  * controller before competition instead of using this.
  */
 public class MultiController extends Controller {
-    private final SendableChooser<Controller> controllerChooser = new SendableChooser<Controller>();
+    private final SendableChooser<Controller> controllerChooser = new SendableChooser<>();
+    private final Xbox defaultXbox = new Xbox(0);
 
     public MultiController() {
         DriverStation.silenceJoystickConnectionWarning(true);
-        controllerChooser.setDefaultOption("Xbox Controller", new Xbox(0));
+        controllerChooser.setDefaultOption("Xbox Controller", defaultXbox);
         controllerChooser.addOption("Logitech Flight Stick", new LogitechFlightStick(1));
         controllerChooser.addOption("Simulation Keyboard", new SimulationKeyboard(2));
         controllerChooser.addOption("8BitDo Controller", new Xbox(3));
         controllerChooser.addOption("Linux 8BitDo Controller", new Linux8BitDo(4));
-        SmartDashboard.putData("Controller Chooser", controllerChooser);
+        DashboardManager.setupControllerChooser(controllerChooser);
     }
 
-    @Override
-    double getRotation() {
-        return controllerChooser.getSelected().getRotation();
+    /**
+     * Returns the Xbox controller if connected to the real field, otherwise returns whatever is selected on the
+     * Controller Chooser in Elastic.
+     */
+    private Controller getActiveController() {
+        return DriverStation.isFMSAttached() ? defaultXbox : controllerChooser.getSelected();
     }
 
     @Override
     Translation2d getTranslation() {
-        return controllerChooser.getSelected().getTranslation();
+        return getActiveController().getTranslation();
+    }
+
+    @Override
+    double getRotation() {
+        return getActiveController().getRotation();
     }
 
     @Override
     Trigger runIntake() {
-        return new Trigger(() -> controllerChooser.getSelected().runIntake().getAsBoolean());
+        return new Trigger(() -> getActiveController().runIntake().getAsBoolean());
     }
 
     @Override
     Trigger shootFuel() {
-        return new Trigger(() -> controllerChooser.getSelected().shootFuel().getAsBoolean());
+        return new Trigger(() -> getActiveController().shootFuel().getAsBoolean());
     }
 
     @Override
     Trigger lowerIntake() {
-        return new Trigger(() -> controllerChooser.getSelected().lowerIntake().getAsBoolean());
+        return new Trigger(() -> getActiveController().lowerIntake().getAsBoolean());
     }
 
     @Override
     Trigger raiseIntake() {
-        return new Trigger(() -> controllerChooser.getSelected().raiseIntake().getAsBoolean());
+        return new Trigger(() -> getActiveController().raiseIntake().getAsBoolean());
     }
 
     @Override
     Trigger aimHandler() {
-        return new Trigger(() -> controllerChooser.getSelected().aimHandler().getAsBoolean());
+        return new Trigger(() -> getActiveController().aimHandler().getAsBoolean());
     }
 
     @Override
     Trigger manualFlywheel() {
-        return new Trigger(() -> controllerChooser.getSelected().manualFlywheel().getAsBoolean());
+        return new Trigger(() -> getActiveController().manualFlywheel().getAsBoolean());
     }
 
     @Override
     Trigger seedFieldCentric() {
-        return new Trigger(() -> controllerChooser.getSelected().seedFieldCentric().getAsBoolean());
+        return new Trigger(() -> getActiveController().seedFieldCentric().getAsBoolean());
     }
 
     @Override
     Trigger reverse() {
-        return new Trigger(() -> controllerChooser.getSelected().reverse().getAsBoolean());
+        return new Trigger(() -> getActiveController().reverse().getAsBoolean());
     }
 
     @Override
     Trigger trenchPath() {
-        return new Trigger(() -> controllerChooser.getSelected().trenchPath().getAsBoolean());
+        return new Trigger(() -> getActiveController().trenchPath().getAsBoolean());
     }
 
     @Override
     Trigger povUp() {
-        return new Trigger(() -> controllerChooser.getSelected().povUp().getAsBoolean());
+        return new Trigger(() -> getActiveController().povUp().getAsBoolean());
     }
 
     @Override
     Trigger povDown() {
-        return new Trigger(() -> controllerChooser.getSelected().povDown().getAsBoolean());
+        return new Trigger(() -> getActiveController().povDown().getAsBoolean());
     }
 
     @Override
     Trigger povLeft() {
-        return new Trigger(() -> controllerChooser.getSelected().povLeft().getAsBoolean());
+        return new Trigger(() -> getActiveController().povLeft().getAsBoolean());
     }
 
     @Override
     Trigger povRight() {
-        return new Trigger(() -> controllerChooser.getSelected().povRight().getAsBoolean());
+        return new Trigger(() -> getActiveController().povRight().getAsBoolean());
     }
 
     @Override
     Trigger forwardSysIdQuasi() {
-        return new Trigger(() -> controllerChooser.getSelected().forwardSysIdQuasi().getAsBoolean());
+        return new Trigger(() -> getActiveController().forwardSysIdQuasi().getAsBoolean());
     }
 
     @Override
     Trigger backwardSysIdQuasi() {
-        return new Trigger(() -> controllerChooser.getSelected().backwardSysIdQuasi().getAsBoolean());
+        return new Trigger(() -> getActiveController().backwardSysIdQuasi().getAsBoolean());
     }
 
     @Override
     Trigger forwardSysIdDynamic() {
-        return new Trigger(() -> controllerChooser.getSelected().forwardSysIdDynamic().getAsBoolean());
+        return new Trigger(() -> getActiveController().forwardSysIdDynamic().getAsBoolean());
     }
 
     @Override
     Trigger backwardSysIdDynamic() {
-        return new Trigger(() -> controllerChooser.getSelected().backwardSysIdDynamic().getAsBoolean());
+        return new Trigger(() -> getActiveController().backwardSysIdDynamic().getAsBoolean());
     }
 }


### PR DESCRIPTION
Closes #94 and builds on #96. Lightly tested in sim. I want you guys to try it too.

Replaces `Robot.IS_COMPETITION` with automatic FMS detection to ensure the robot behaves correctly on the field without requiring manual code updates.

Updates `MultiController`'s logic to automatically default to the Xbox controller when connected to the field, maintaining the failsafe for competition while allowing flexibility during testing. Additionally, organizes `Controller Chooser` and `Aim At Target PID Controller` in Elastic's `Debug` folder.